### PR TITLE
Fly.ioの設定修正(#8)

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -12,7 +12,7 @@ console_command = "/rails/bin/rails console"
 [http_service]
   internal_port = 3000
   force_https = true
-  auto_stop_machines = true
+  auto_stop_machines = false
   auto_start_machines = true
   min_machines_running = 0
   processes = ["app"]
@@ -34,7 +34,7 @@ console_command = "/rails/bin/rails console"
 [[vm]]
   cpu_kind = "shared"
   cpus = 1
-  memory_mb = 1024
+  memory_mb = 256
 
 [[statics]]
   guest_path = "/rails/public"


### PR DESCRIPTION
## 実装概要
- 10分ほどアクセスがないとサーバーが落ちてしまう為、Fly.ioの設定を修正して対応する
- メモリの設定がデフォルトだと課金設定になっているので、無料範囲の256MBに変更する

## 目的
- サーバーが落ちていると初回アクセスに時間がかかるので常時立ち上がっているようにする
- メモリ使用量で課金されることを防ぐ

## 参考情報
- [サーバーが落ちるのを防ぐことについて](https://community.fly.io/t/hobby-plan-deployed-apps-are-suspended-within-minutes-how-to-fix/12322)
- [メモリの設定について](https://zenn.dev/rrraaa/articles/1c7c79d51786c7)