### PR TITLE
Issue/12

### DIFF
--- a/.devcontainer/dev.dockerfile
+++ b/.devcontainer/dev.dockerfile
@@ -9,7 +9,7 @@ ENV ROOT="/workspaces/shopping_app"
 WORKDIR ${ROOT}
 
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y build-essential  postgresql-client tig libpq-dev
+    apt-get install --no-install-recommends -y build-essential  postgresql-client libpq-dev
 
 RUN bundle config set --local path .bundle
 RUN mkdir -p ${ROOT}/.bundle

--- a/.devcontainer/dev.dockerfile
+++ b/.devcontainer/dev.dockerfile
@@ -10,10 +10,7 @@ WORKDIR ${ROOT}
 
 RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y build-essential  postgresql-client tig libpq-dev
-COPY Gemfile ${ROOT}
-COPY Gemfile.lock ${ROOT}
 
 RUN bundle config set --local path .bundle
 RUN mkdir -p ${ROOT}/.bundle
 RUN chown -R vscode:vscode ${ROOT}/.bundle
-RUN su vscode -c "bundle install"

--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -1,5 +1,8 @@
 #!/bin/bash -e
 
+echo 'bundle installを開始'
+bundle install
+
 MAX_ATTEMPTS=10
 attempt=1
 


### PR DESCRIPTION
## 実装概要
- bundle install をdocker-entrypoint内で実行するように設定

## 目的
- bundle installがDockerfile編集の度に再度実行されることを防ぐ

## 具体的な修正内容
- bundle installを実行

## 動作確認
### 動作確認画面
- 1度アプリのディレクトリを削除した後、再度cloneしてビルドしたが、そこまで時間がかかっていないことを確認。

![image](https://github.com/yuta-saito-0310/shopping_app/assets/132235214/d1d7b5b9-b456-4308-861a-13f3616b74b9)